### PR TITLE
DEV-03: Enable Docker live reload

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,9 +25,9 @@ services:
       - ROLLUP_DISABLE_NATIVE=1
     ports:
       - "5173:5173" 
-    # volumes:
-    #   - ./src/vulnerability-frontend:/app
-    #   - node_modules:/app/node_modules
+    volumes:
+      - ./src/vulnerability-frontend:/app
+      - node_modules:/app/node_modules
     networks:
       - app-network
     depends_on:

--- a/src/vulnerability-frontend/vite.config.js
+++ b/src/vulnerability-frontend/vite.config.js
@@ -8,4 +8,10 @@ export default defineConfig({
       crypto: 'crypto-browserify',
     },
   },
+  server: {
+    host: '0.0.0.0',
+    watch: {
+      usePolling: true,
+    },
+  },
 })


### PR DESCRIPTION
# DEV-03: Enable Docker Live Reload  

## Summary  
This PR enables live reload for the Dockerized frontend by adjusting volume settings and updating Vite's configuration.  

## Changes  
- **Uncommented volumes** in `docker-compose.yml` to mount frontend code and `node_modules`.  
- **Configured Vite** to enable live reload:  
  - Set `server.host = '0.0.0.0'` to allow external access.  
  - Enabled `watch.usePolling = true` to detect file changes inside the container.  

## Testing  
- Ran `docker-compose up --build` and verified that frontend changes reflect without restarting the container.  

## Issue Reference  
This resolves [DEV-03: Enable Docker live reload](https://github.com/Rix95/Senior-Project-REPO/issues/20).  

**Owner:** Richard Rich  
