### PR TITLE
FE-03: add dynamic vulnerability timeline endpoint and frontend filte…

### DIFF
--- a/src/backend/api/main.py
+++ b/src/backend/api/main.py
@@ -7,6 +7,7 @@ from osv.fetch_osv_ids import extract_vulnerability_ids
 from osv.osv_vuln_neo4j_loader import main as load_osv
 from osv.neo4j_connection import get_neo4j_driver
 from apscheduler.schedulers.background import BackgroundScheduler
+from routers.items.vulnerability_timeline import router as timeline_router
 
 
 app = FastAPI()
@@ -19,7 +20,7 @@ app.add_middleware(
 )
 
 app.include_router(osv_vulnerabilities_router, prefix="/items/osv_vulnerabilities", tags=["OSV_Vulnerabilities"])
-
+app.include_router(timeline_router, prefix="/items", tags=["vulnerability_timeline"])
 
 @app.get("/")
 def main():
@@ -41,8 +42,6 @@ async def update_osv_vulnerabilities():
 scheduler = BackgroundScheduler()
 scheduler.add_job(update_osv_vulnerabilities, "interval", weeks=1)
 scheduler.start()
-
-
 
 #Refactor eventually!
 # Query function to count Vulnerability nodes

--- a/src/backend/api/routers/items/vulnerability_timeline.py
+++ b/src/backend/api/routers/items/vulnerability_timeline.py
@@ -1,0 +1,34 @@
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+from typing import List
+from osv.neo4j_connection import get_neo4j_driver
+
+router = APIRouter()
+
+# Pydantic model for our time-series data
+class VulnerabilityDailyCount(BaseModel):
+    date: str
+    count: int
+
+@router.get("/vulnerability_timeline", response_model=List[VulnerabilityDailyCount])
+async def get_vulnerability_timeline(driver=Depends(get_neo4j_driver)):
+    """
+    Return daily counts of vulnerabilities for charting.
+    This query assumes v.published is an ISO date/time string
+    that can be converted via datetime(...).
+    Adjust as needed for your actual data format.
+    """
+    query = """
+    MATCH (v:Vulnerability)
+    WHERE v.published IS NOT NULL
+    WITH date(datetime(v.published)) AS publishedDate
+    RETURN publishedDate AS date, count(*) AS count
+    ORDER BY date ASC
+    """
+    with driver.session() as session:
+        result = session.run(query)
+        data = [
+            {"date": str(record["date"]), "count": record["count"]}
+            for record in result
+        ]
+        return data

--- a/src/vulnerability-frontend/src/App.vue
+++ b/src/vulnerability-frontend/src/App.vue
@@ -1,9 +1,8 @@
+<!-- src/App.vue -->
 <script setup>
 import { ref, onMounted } from 'vue'
 import { Chart } from 'chart.js/auto'
-
-// Import API functions
-import { getVulnerabilityCount, getLastUpdated } from './services/api'
+import { getVulnerabilityCount, getLastUpdated, getVulnerabilityTimeline } from './services/api'
 
 // Sidebar items
 const menuItems = [
@@ -14,12 +13,12 @@ const menuItems = [
 const selectedMenu = ref(menuItems[0].name)
 
 // Live data from the backend
-const vulnerabilities = ref(null)  
-const lastUpdated = ref(null)      
+const vulnerabilities = ref(null)
+const lastUpdated = ref(null)
 
-// Chart data for the 7-day bar chart
-const vulnerabilityData = ref([120, 110, 115, 130, 125, 140, 135])
-const days = ref(["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"])
+// Chart data (was previously hardcoded)
+const days = ref([])
+const vulnerabilityData = ref([])
 
 // Function to convert Epoch timestamp to Central Time (CT)
 const formatDate = (timestamp) => {
@@ -38,40 +37,60 @@ const formatDate = (timestamp) => {
   }).format(new Date(timestamp));
 };
 
-// On mount, fetch real-time data
 onMounted(async () => {
-  // Render the bar chart
-  const ctx = document.getElementById('vulnerabilityChart')
-  new Chart(ctx, {
-    type: 'bar',
-    data: {
-      labels: days.value,
-      datasets: [
-        {
-          label: 'Vulnerabilities',
-          data: vulnerabilityData.value,
-          backgroundColor: 'rgba(231, 76, 60, 0.6)',
-          borderColor: 'rgba(231, 76, 60, 1)',
-          borderWidth: 1
-        }
-      ]
-    },
-    options: {
-      responsive: true,
-      scales: {
-        y: { beginAtZero: true }
-      }
-    }
-  })
-
-  // Fetch total vulnerabilities & last-updated timestamp
   try {
+    // 1) Fetch the timeline data for the bar chart
+    const timelineResp = await getVulnerabilityTimeline()
+    const timeline = timelineResp.data
+    // timeline might have old data going back to 2000, so let's filter
+
+    // Example: show only the last 30 days
+    const now = new Date()
+    const cutoff = new Date(now)
+    cutoff.setDate(cutoff.getDate() - 30) // 30 days ago
+
+    // Filter the timeline to keep only records on/after the cutoff
+    const filteredTimeline = timeline.filter(item => {
+      const itemDate = new Date(item.date)
+      return itemDate >= cutoff
+    })
+
+    // Fill arrays for the bar chart with filtered data
+    days.value = filteredTimeline.map(item => item.date)
+    vulnerabilityData.value = filteredTimeline.map(item => item.count)
+
+    // 2) Render the bar chart
+    const ctx = document.getElementById('vulnerabilityChart')
+    new Chart(ctx, {
+      type: 'bar',
+      data: {
+        labels: days.value,  // dynamic
+        datasets: [
+          {
+            label: 'Vulnerabilities (Past 30 Days)',
+            data: vulnerabilityData.value,
+            backgroundColor: 'rgba(231, 76, 60, 0.6)',
+            borderColor: 'rgba(231, 76, 60, 1)',
+            borderWidth: 1
+          }
+        ]
+      },
+      options: {
+        responsive: true,
+        scales: {
+          y: { beginAtZero: true }
+        }
+      }
+    })
+
+    // 3) Fetch total vulnerabilities & last-updated
     const [countRes, updatedRes] = await Promise.all([
       getVulnerabilityCount(),
       getLastUpdated()
     ])
     vulnerabilities.value = countRes.data?.total_vulnerabilities
     lastUpdated.value = updatedRes.data?.last_updated
+
   } catch (error) {
     console.error('Error fetching data:', error)
   }
@@ -118,9 +137,9 @@ onMounted(async () => {
           </p>
         </div>
 
-        <!-- 7-day bar chart card -->
+        <!-- 30-day bar chart card -->
         <div class="card">
-          <h3>Vulnerabilities (Last 7 Days)</h3>
+          <h3>Vulnerabilities (Last 30 Days)</h3>
           <canvas id="vulnerabilityChart"></canvas>
         </div>
       </section>

--- a/src/vulnerability-frontend/src/services/api.js
+++ b/src/vulnerability-frontend/src/services/api.js
@@ -6,9 +6,10 @@ const apiClient = axios.create({
   timeout: 10000
 })
 
-// Optionally define helper functions for clarity
+// Helper functions for clarity
 export const getVulnerabilityCount = () => apiClient.get('/count_vulnerabilities')
 export const getLastUpdated = () => apiClient.get('/last_updated')
+export const getVulnerabilityTimeline = () => apiClient.get('/items/vulnerability_timeline')
 
-// Export the client in case you want to do direct calls
+// Export the client since we want to do direct calls
 export default apiClient

--- a/src/vulnerability-frontend/src/views/Dashboard.vue
+++ b/src/vulnerability-frontend/src/views/Dashboard.vue
@@ -1,48 +1,78 @@
 <!-- src/views/Dashboard.vue -->
 <template>
-    <div>
-      <el-card>
-        <h2>Vulnerability Trends</h2>
-        <line-chart :chart-data="chartData" :chart-options="chartOptions"></line-chart>
-      </el-card>
-    </div>
-  </template>
-  
-  <script>
-  import { Line } from 'vue-chartjs'
-  import { defineComponent } from 'vue'
-  import { Chart, registerables } from 'chart.js'
-  Chart.register(...registerables)
-  
-  export default defineComponent({
-    name: 'Dashboard',
-    components: {
-      lineChart: {
-        extends: Line,
-        props: ['chartData', 'chartOptions'],
-        mounted() {
-          this.renderChart(this.chartData, this.chartOptions)
-        }
-      }
-    },
-    data() {
-      return {
-        chartData: {
-          labels: ['January', 'February', 'March', 'April'],
-          datasets: [
-            {
-              label: 'Detected Vulnerabilities',
-              backgroundColor: '#f87979',
-              data: [40, 20, 12, 39]
-            }
-          ]
-        },
-        chartOptions: {
-          responsive: true,
-          maintainAspectRatio: false
+  <div>
+    <el-card>
+      <h2>Vulnerability Trends</h2>
+      <!-- The line chart uses our reactive chartData. -->
+      <line-chart :chart-data="chartData" :chart-options="chartOptions"></line-chart>
+    </el-card>
+  </div>
+</template>
+
+<script>
+import { Line } from 'vue-chartjs'
+import { defineComponent, onMounted, ref } from 'vue'
+import { Chart, registerables } from 'chart.js'
+import { getVulnerabilityTimeline } from '../services/api' // or '../services/api'
+
+Chart.register(...registerables)
+
+export default defineComponent({
+  name: 'Dashboard',
+  components: {
+    lineChart: {
+      extends: Line,
+      props: ['chartData', 'chartOptions'],
+      mounted() {
+        this.renderChart(this.chartData, this.chartOptions)
+      },
+      watch: {
+        // If chartData changes after initial load, re-render the chart:
+        chartData(newVal) {
+          this.renderChart(newVal, this.chartOptions)
         }
       }
     }
-  })
-  </script>
-  
+  },
+  setup() {
+    // Reactive chart data
+    const chartData = ref({
+      labels: [],
+      datasets: [
+        {
+          label: 'Detected Vulnerabilities',
+          // You can remove or customize your color as needed:
+          backgroundColor: '#f87979',
+          data: []
+        }
+      ]
+    })
+
+    const chartOptions = ref({
+      responsive: true,
+      maintainAspectRatio: false
+    })
+
+    onMounted(async () => {
+      try {
+        // 1) Fetch dynamic data from the new endpoint
+        const response = await getVulnerabilityTimeline()
+        // response.data should be something like:
+        // [ { date: "2025-03-28", count: 15 }, { date: "2025-03-29", count: 22 }, ... ]
+
+        const timelineData = response.data
+        // 2) Fill our labels & data arrays from the response
+        chartData.value.labels = timelineData.map(item => item.date)
+        chartData.value.datasets[0].data = timelineData.map(item => item.count)
+      } catch (error) {
+        console.error('Error fetching vulnerability timeline:', error)
+      }
+    })
+
+    return {
+      chartData,
+      chartOptions
+    }
+  }
+})
+</script>


### PR DESCRIPTION
# FE-03: add dynamic vulnerability timeline endpoint and frontend filter
## Owner: Richard Rich
## Code Changes:
- Created new router file `src/backend/api/routers/items/vulnerability_timeline.py` to expose a GET endpoint (`/items/vulnerability_timeline`) that returns daily vulnerability counts.
- Updated `src/backend/api/main.py` to include the new timeline router.
- Added `getVulnerabilityTimeline` function in `src/vulnerability-frontend/src/services/api.js` to call the new endpoint.
- Updated frontend charts in `Dashboard.vue` and `App.vue` to fetch dynamic timeline data instead of using hardcoded values.
- Implemented frontend filtering in `App.vue` to restrict the displayed timeline to the last 30 days, ensuring the chart does not span back to the year 2000.

This change has been tested and works as expected. 
![image](https://github.com/user-attachments/assets/90affb80-6233-46fa-a61a-ac36b0cddf5a)

